### PR TITLE
Fix broken composer licenses command call

### DIFF
--- a/src/DependencyLoader.php
+++ b/src/DependencyLoader.php
@@ -21,7 +21,7 @@ class DependencyLoader implements DependencyLoaderContract
 
     private function runComposerLicenseCommand(string $composer, string $project): array
     {
-        $command = sprintf('%s -d %s licenses', $composer, $project);
+        $command = sprintf('%s licenses -d %s', $composer, $project);
 
         return $this->exec($command);
     }

--- a/tests/DependencyLoaderTest.php
+++ b/tests/DependencyLoaderTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dominikb\ComposerLicenseChecker\Tests;
 
-use Mockery;
 use Dominikb\ComposerLicenseChecker\DependencyLoader;
+use Mockery;
 
 class DependencyLoaderTest extends TestCase
 {
@@ -34,6 +34,6 @@ class DependencyLoaderTest extends TestCase
 
         $loader->loadDependencies('./composerpath/composer-binary', '/some/directory');
 
-        $this->assertEquals('./composerpath/composer-binary -d /some/directory licenses', $command);
+        $this->assertEquals('./composerpath/composer-binary licenses -d /some/directory', $command);
     }
 }


### PR DESCRIPTION
Calling
```
composer -d /somedir licenses
```
will cause
```
[Symfony\Component\Console\Exception\CommandNotFoundException]
Command "/somedir" is not defined.
```
It should be called as:
```
composer licenses -d /somedir
```

More [here](https://github.com/composer/composer/issues/8927).