### PR TITLE
Return command exit code

### DIFF
--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -65,7 +65,7 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
     /**
      * @throws CommandExecutionException
      */
-    public function execute(InputInterface $input, OutputInterface $output): void
+    public function execute(InputInterface $input, OutputInterface $output)
     {
         $this->logger = new ConsoleLogger($output);
         $this->io = new SymfonyStyle($input, $output);
@@ -89,7 +89,10 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
             $this->io->success('Command finished successfully. No violations detected!');
         } catch (CommandExecutionException $exception) {
             $this->io->error($exception->getMessage());
+            return 1;
         }
+        
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Command::execute should return int 0 if everything went fine, or an exit code.

Otherwise the fatal error is produced:
```
PHP Fatal error:  Uncaught TypeError: Return value of "Dominikb\ComposerLicenseChecker\CheckCommand::execute()" must be of the type int, "null" returned. in /root/.composer/vendor/symfony/console/Command/Command.php:261
```