### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/ConstraintViolationDetector.php
+++ b/src/ConstraintViolationDetector.php
@@ -66,7 +66,7 @@ class ConstraintViolationDetector implements LicenseConstraintHandler
 
         if (count($overlap) > 0) {
             $invalidLicenseConditionals = sprintf('"%s"', implode('", "', $overlap));
-            throw new LogicException("Licenses must not be on the block- and allowlist at the same time: ${invalidLicenseConditionals}");
+            throw new LogicException("Licenses must not be on the block- and allowlist at the same time: {$invalidLicenseConditionals}");
         }
     }
 


### PR DESCRIPTION
When running, it throws the following deprecation warning, so just fixing that:

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in ~/.composer/vendor/dominikb/composer-license-checker/src/ConstraintViolationDetector.php on line 69

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ~/.composer/vendor/dominikb/composer-license-checker/src/ConstraintViolationDetector.php on line 69
```