### PR TITLE
Add support for symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         "composer/composer": "^1.10.27|~2.2.22|^2.6.4",
         "guzzlehttp/guzzle": "^6.3|^7.2",
         "psr/simple-cache": "^1.0|^2.0|^3.0",
-        "symfony/cache": "^4.2.3|^5.2|^6.0",
-        "symfony/css-selector": "^4.2|^5.2|^6.0",
-        "symfony/dom-crawler": "^5.2|^6.0"
+        "symfony/cache": "^4.2.3|^5.2|^6.0|^7.0",
+        "symfony/css-selector": "^4.2|^5.2|^6.0|^7.0",
+        "symfony/dom-crawler": "^5.2|^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
         "phpunit/phpunit": "^9.3",
-        "symfony/var-dumper": "^4.2|^5.2|^6.0"
+        "symfony/var-dumper": "^4.2|^5.2|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Symfony 7 was released as beta, allowing support for symfony 7 helps downstream projects to migrate to symfony 7 as well