### PR TITLE
Fix compatibility with symfony 7

### DIFF
--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -18,17 +18,11 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-#[AsCommand(
-    name: 'check',
-    description: 'Checks the licenses of all dependencies',
-)]
 class CheckCommand extends Command implements LicenseLookupAware, LicenseConstraintAware, DependencyLoaderAware
 {
     use LicenseLookupAwareTrait, LicenseConstraintAwareTrait, DependencyLoaderAwareTrait;
 
     const LINES_BEFORE_DEPENDENCY_VERSIONS = 2;
-
-    protected static $defaultName = 'check';
 
     /** @var ConsoleLogger */
     private $logger;
@@ -71,6 +65,11 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
                 'Determine a vendor or package to always be allowed and never trigger violations'
             ),
         ]));
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'check';
     }
 
     /**

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -9,6 +9,7 @@ use Dominikb\ComposerLicenseChecker\Exceptions\CommandExecutionException;
 use Dominikb\ComposerLicenseChecker\Traits\DependencyLoaderAwareTrait;
 use Dominikb\ComposerLicenseChecker\Traits\LicenseConstraintAwareTrait;
 use Dominikb\ComposerLicenseChecker\Traits\LicenseLookupAwareTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,6 +18,10 @@ use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+#[AsCommand(
+    name: 'check',
+    description: 'Checks the licenses of all dependencies',
+)]
 class CheckCommand extends Command implements LicenseLookupAware, LicenseConstraintAware, DependencyLoaderAware
 {
     use LicenseLookupAwareTrait, LicenseConstraintAwareTrait, DependencyLoaderAwareTrait;
@@ -71,7 +76,7 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
     /**
      * @throws CommandExecutionException
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->logger = new ConsoleLogger($output);
         $this->io = new SymfonyStyle($input, $output);

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -9,7 +9,6 @@ use Dominikb\ComposerLicenseChecker\Exceptions\CommandExecutionException;
 use Dominikb\ComposerLicenseChecker\Traits\DependencyLoaderAwareTrait;
 use Dominikb\ComposerLicenseChecker\Traits\LicenseConstraintAwareTrait;
 use Dominikb\ComposerLicenseChecker\Traits\LicenseLookupAwareTrait;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/ReportCommand.php
+++ b/src/ReportCommand.php
@@ -9,6 +9,7 @@ use Dominikb\ComposerLicenseChecker\Contracts\LicenseLookupAware;
 use Dominikb\ComposerLicenseChecker\Traits\DependencyLoaderAwareTrait;
 use Dominikb\ComposerLicenseChecker\Traits\LicenseLookupAwareTrait;
 use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -16,6 +17,10 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'report',
+    description: 'Reports the licenses of all dependencies',
+)]
 class ReportCommand extends Command implements LicenseLookupAware, DependencyLoaderAware
 {
     use LicenseLookupAwareTrait, DependencyLoaderAwareTrait;

--- a/src/ReportCommand.php
+++ b/src/ReportCommand.php
@@ -9,7 +9,6 @@ use Dominikb\ComposerLicenseChecker\Contracts\LicenseLookupAware;
 use Dominikb\ComposerLicenseChecker\Traits\DependencyLoaderAwareTrait;
 use Dominikb\ComposerLicenseChecker\Traits\LicenseLookupAwareTrait;
 use Symfony\Component\Cache\Adapter\NullAdapter;
-use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputDefinition;

--- a/src/ReportCommand.php
+++ b/src/ReportCommand.php
@@ -17,15 +17,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-#[AsCommand(
-    name: 'report',
-    description: 'Reports the licenses of all dependencies',
-)]
 class ReportCommand extends Command implements LicenseLookupAware, DependencyLoaderAware
 {
     use LicenseLookupAwareTrait, DependencyLoaderAwareTrait;
-
-    protected static $defaultName = 'report';
 
     protected function configure()
     {
@@ -69,6 +63,11 @@ class ReportCommand extends Command implements LicenseLookupAware, DependencyLoa
                 'Filter for specific licences.'
             ),
         ]));
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'report';
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
Now the check and report commands are running as expected with symfony 7.

Adding the attribute shouldn't be an issue as it should be ignored if it does not exist right?