### PR TITLE
Escape "composer license" command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Use `./composer-license-checker help` to get info about general usage or use the
 vendor/bin/composer-license-checker report -p /path/to/your/project -c /path/to/composer.phar
 ```
 
+### Exit codes
+
+Any command returns with one of these exit codes:
+
+- 0: Ok
+- 1: Offending licenses found in check, or a problem occurred when creating a report
+- 2: Internal error when executing the command, may indicate problems calling Composer internally
+
 ### Testing
 
 ``` bash

--- a/src/DependencyLoader.php
+++ b/src/DependencyLoader.php
@@ -26,9 +26,9 @@ class DependencyLoader implements DependencyLoaderContract
         return $this->dependencyParser->parse(join(PHP_EOL, $commandOutput));
     }
 
-    private function runComposerLicenseCommand(string $composer, string $project, string $format = 'json'): array
+    private function runComposerLicenseCommand(string $composer, string $project): array
     {
-        $command = sprintf('%s licenses -f %s -d %s', $composer, $format, $project);
+        $command = sprintf('%s licenses --format json --working-dir %s', escapeshellarg($composer), escapeshellarg($project));
 
         return $this->exec($command);
     }

--- a/src/DependencyLoader.php
+++ b/src/DependencyLoader.php
@@ -6,6 +6,8 @@ namespace Dominikb\ComposerLicenseChecker;
 
 use Dominikb\ComposerLicenseChecker\Contracts\DependencyLoader as DependencyLoaderContract;
 use Dominikb\ComposerLicenseChecker\Contracts\DependencyParser;
+use Dominikb\ComposerLicenseChecker\Exceptions\CommandExecutionException;
+use Symfony\Component\Console\Command\Command;
 
 class DependencyLoader implements DependencyLoaderContract
 {
@@ -19,6 +21,9 @@ class DependencyLoader implements DependencyLoaderContract
         $this->dependencyParser = $dependencyParser;
     }
 
+    /**
+     * @throws CommandExecutionException
+     */
     public function loadDependencies(string $composer, string $project): array
     {
         $commandOutput = $this->runComposerLicenseCommand($composer, $project);
@@ -26,6 +31,9 @@ class DependencyLoader implements DependencyLoaderContract
         return $this->dependencyParser->parse(join(PHP_EOL, $commandOutput));
     }
 
+    /**
+     * @throws CommandExecutionException
+     */
     private function runComposerLicenseCommand(string $composer, string $project): array
     {
         $command = sprintf('%s licenses --format json --working-dir %s', escapeshellarg($composer), escapeshellarg($project));
@@ -33,9 +41,16 @@ class DependencyLoader implements DependencyLoaderContract
         return $this->exec($command);
     }
 
-    protected function exec(string $command)
+    /**
+     * @throws CommandExecutionException
+     */
+    protected function exec(string $command): array
     {
-        exec($command, $output);
+        exec($command, $output, $exitCode);
+
+        if ($exitCode !== 0) {
+            throw new CommandExecutionException('Error when trying to fetch licenses from Composer', Command::INVALID);
+        }
 
         return $output;
     }

--- a/tests/DependencyLoaderTest.php
+++ b/tests/DependencyLoaderTest.php
@@ -6,11 +6,18 @@ namespace Dominikb\ComposerLicenseChecker\Tests;
 
 use Dominikb\ComposerLicenseChecker\Contracts\DependencyParser;
 use Dominikb\ComposerLicenseChecker\DependencyLoader;
+use Dominikb\ComposerLicenseChecker\Exceptions\CommandExecutionException;
 use Mockery;
+use Symfony\Component\Console\Command\Command;
 
 class DependencyLoaderTest extends TestCase
 {
-    /** @test */
+    /**
+     * @test
+     *
+     * @requires OSFAMILY Linux|Darwin
+     * Linux required because of escape characters in the verified command
+     */
     public function it_runs_the_command_with_the_given_inputs()
     {
         $loader = Mockery::mock(DependencyLoader::class, [$this->createNoOpParser()])
@@ -18,16 +25,33 @@ class DependencyLoaderTest extends TestCase
 
         $command = '';
         $loader->shouldAllowMockingProtectedMethods()
-               ->shouldReceive('exec')
-               ->once()
+               ->expects('exec')
                ->withArgs(function ($c) use (&$command) {
                    return (bool) ($command = $c);
                })
-               ->andReturn([]);
+               ->andReturns([]);
 
         $loader->loadDependencies('./composerpath/composer-binary', '/some/directory');
 
-        $this->assertEquals('./composerpath/composer-binary licenses -f json -d /some/directory', $command);
+        $this->assertEquals("'./composerpath/composer-binary' licenses --format json --working-dir '/some/directory'", $command);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_on_exec_failure()
+    {
+        $loader = Mockery::mock(DependencyLoader::class, [$this->createNoOpParser()])
+            ->makePartial();
+
+        $command = '';
+        $loader->shouldAllowMockingProtectedMethods()
+            ->expects('exec')
+            ->andThrows(CommandExecutionException::class, 'Error when trying to fetch licenses from Composer', Command::INVALID);
+
+        $this->expectException(CommandExecutionException::class);
+        $this->expectExceptionCode(2);
+        $loader->loadDependencies('./composerpath/composer-binary', '/some/directory');
     }
 
     public function createNoOpParser(): DependencyParser

--- a/tests/DependencyLoaderTest.php
+++ b/tests/DependencyLoaderTest.php
@@ -15,7 +15,7 @@ class DependencyLoaderTest extends TestCase
     /**
      * @test
      *
-     * @requires OSFAMILY Linux|Darwin
+     * @requires OS Linux|Darwin
      * Linux required because of escape characters in the verified command
      */
     public function it_runs_the_command_with_the_given_inputs()


### PR DESCRIPTION
Addresses the missing escaping and success validation in #39 

This introduces a new exit code 2 for situations when the internal command execution is failing, i.e. it is possible to signal "licenses don't fit" independent from "internal issue" if that's relevant for the consumer.

I switched to using the long command-line parameters as they better explain what they are doing.