### PR TITLE
Fix default composer location

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Use `./composer-license-checker help` to get info about general usage or use the
 vendor/bin/composer-license-checker report -p /path/to/your/project -c /path/to/composer.phar
 ```
 
+### Path to composer
+
+By default, this tool assumes that "composer" is in your path and a valid command that will call Composer.
+
+If that isn't the case, add the `-c` or `--composer` option with the path where to find Composer instead.
+This tool comes with Composer installed as a dependency, so you may start with `--composer ./vendor/bin/composer`, given that you are in this tool's root directory when executing a license check.
+
+If this tool cannot find Composer, it will exit with status code 2, see below.
+
 ### Exit codes
 
 Any command returns with one of these exit codes:

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -40,7 +40,7 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
                 'c',
                 InputOption::VALUE_OPTIONAL,
                 'Path to composer executable',
-                realpath('./vendor/bin/composer')
+                'composer'
             ),
             new InputOption(
                 'allowlist',

--- a/src/ReportCommand.php
+++ b/src/ReportCommand.php
@@ -35,7 +35,7 @@ class ReportCommand extends Command implements LicenseLookupAware, DependencyLoa
                 'c',
                 InputOption::VALUE_OPTIONAL,
                 'Path to composer executable',
-                realpath('./vendor/bin/composer')
+                'composer'
             ),
             new InputOption(
                 'no-cache',


### PR DESCRIPTION
The tool runs "composer license..." as a shell command and needs to know where to find Composer.

Previously the "./vendor/bin/composer" path based on the current directory has been used. This is the bundled Composer version only if the "composer-check-license" command is executed from within the installed repository of this tool, or as a dependency of a repository. If the current directory is somewhere else, this path is not working anymore and would require an explicit `--composer` option being passed.

However, everything in the documentation only talks about running Composer as it is available in the path, i.e. "You can install the package via composer: `composer require --dev dominikb/composer-license-checker`". This indicates that "composer" is a command available on the CLI already.

With that in mind, I opted for defaulting to a simple "`composer`" as the default value, and if that does not work, prior PRs already detect failing execution and exit with status 2. The string is directly passed into the "$value license..." command string, i.e. would yield "composer license...", which sounds sane given the exact same command structure is used for installation of this tool.

For anything deviating from default, instructions are added to the readme file.