### PR TITLE
Handle dependencies without a license in CheckCommand

### DIFF
--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -160,7 +160,7 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
     {
         $byLicense = [];
         foreach ($violators as $violator) {
-            foreach($violator->getLicenses() as $license) {
+            foreach ($violator->getLicenses() as $license) {
                 if (! isset($byLicense[$license])) {
                     $byLicense[$license] = [];
                 }

--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -160,12 +160,12 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
     {
         $byLicense = [];
         foreach ($violators as $violator) {
-            $license = $violator->getLicenses()[0];
-
-            if (! isset($byLicense[$license])) {
-                $byLicense[$license] = [];
+            foreach($violator->getLicenses() as $license) {
+                if (! isset($byLicense[$license])) {
+                    $byLicense[$license] = [];
+                }
+                $byLicense[$license][] = $violator;
             }
-            $byLicense[$license][] = $violator;
         }
 
         foreach ($byLicense as $license => $violators) {

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -15,12 +15,16 @@ class Dependency
     /** @var string[] */
     private $licenses;
 
+    // This is a constant that is used to represent the absence of a license.
+    // Matches the value of the 'none' license in the composer.json file.
+    const NO_LICENSES = ['none'];
+
     /**
      * Dependency constructor.
      *
-     * @param  string  $name
-     * @param  string  $version
-     * @param  string[]  $licenses
+     * @param string $name
+     * @param string $version
+     * @param string[] $licenses
      */
     public function __construct(string $name = '', string $version = '', array $licenses = [])
     {
@@ -38,7 +42,7 @@ class Dependency
     }
 
     /**
-     * @param  string  $name
+     * @param string $name
      */
     public function setName(string $name): self
     {
@@ -56,7 +60,7 @@ class Dependency
     }
 
     /**
-     * @param  string  $version
+     * @param string $version
      */
     public function setVersion(string $version): self
     {
@@ -65,16 +69,24 @@ class Dependency
         return $this;
     }
 
+    public function hasAnyLicense(): bool
+    {
+        return !empty($this->licenses);
+    }
+
     /**
      * @return string[]
      */
     public function getLicenses(): array
     {
-        return $this->licenses;
+        if ($this->hasAnyLicense())
+            return $this->licenses;
+        else
+            return self::NO_LICENSES;
     }
 
     /**
-     * @param  string[]  $licenses
+     * @param string[] $licenses
      */
     public function setLicenses(array $licenses): self
     {

--- a/src/Dependency.php
+++ b/src/Dependency.php
@@ -22,9 +22,9 @@ class Dependency
     /**
      * Dependency constructor.
      *
-     * @param string $name
-     * @param string $version
-     * @param string[] $licenses
+     * @param  string  $name
+     * @param  string  $version
+     * @param  string[]  $licenses
      */
     public function __construct(string $name = '', string $version = '', array $licenses = [])
     {
@@ -42,7 +42,7 @@ class Dependency
     }
 
     /**
-     * @param string $name
+     * @param  string  $name
      */
     public function setName(string $name): self
     {
@@ -60,7 +60,7 @@ class Dependency
     }
 
     /**
-     * @param string $version
+     * @param  string  $version
      */
     public function setVersion(string $version): self
     {
@@ -71,7 +71,7 @@ class Dependency
 
     public function hasAnyLicense(): bool
     {
-        return !empty($this->licenses);
+        return ! empty($this->licenses);
     }
 
     /**
@@ -79,14 +79,15 @@ class Dependency
      */
     public function getLicenses(): array
     {
-        if ($this->hasAnyLicense())
+        if ($this->hasAnyLicense()) {
             return $this->licenses;
-        else
+        } else {
             return self::NO_LICENSES;
+        }
     }
 
     /**
-     * @param string[] $licenses
+     * @param  string[]  $licenses
      */
     public function setLicenses(array $licenses): self
     {

--- a/tests/DependencyTest.php
+++ b/tests/DependencyTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dominikb\ComposerLicenseChecker\Tests;
+
+use Dominikb\ComposerLicenseChecker\Dependency;
+use PHPUnit\Framework\TestCase;
+
+class DependencyTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_none_as_default_license_when_no_license_is_provided()
+    {
+        $dependency = new Dependency('name', 'version');
+
+        $this->assertSame(Dependency::NO_LICENSES, $dependency->getLicenses());
+    }
+}


### PR DESCRIPTION
- Report violations for all licenses of a dependency.
- Use 'none' as license name if a dependency does not provide any license by itself.

Original fix in #43 