### PR TITLE
Support --no-dev tag

### DIFF
--- a/src/CheckCommand.php
+++ b/src/CheckCommand.php
@@ -43,6 +43,13 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
                 'composer'
             ),
             new InputOption(
+                'no-dev',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Do not include dev dependencies',
+                'false'
+            ),
+            new InputOption(
                 'allowlist',
                 'a',
                 InputOption::VALUE_IS_ARRAY | InputOption::VALUE_OPTIONAL,
@@ -81,7 +88,8 @@ class CheckCommand extends Command implements LicenseLookupAware, LicenseConstra
 
         $dependencies = $this->dependencyLoader->loadDependencies(
             $input->getOption('composer'),
-            $input->getOption('project-path')
+            $input->getOption('project-path'),
+            ($input->getOption('no-dev') ?? 'true') === 'true'
         );
 
         $this->io->writeln(count($dependencies).' dependencies were found ...');

--- a/src/Contracts/DependencyLoader.php
+++ b/src/Contracts/DependencyLoader.php
@@ -11,5 +11,5 @@ interface DependencyLoader
     /**
      * @return Dependency[]
      */
-    public function loadDependencies(string $composer, string $project): array;
+    public function loadDependencies(string $composer, string $project, bool $withoutDev): array;
 }

--- a/src/DependencyLoader.php
+++ b/src/DependencyLoader.php
@@ -36,7 +36,7 @@ class DependencyLoader implements DependencyLoaderContract
      */
     private function runComposerLicenseCommand(string $composer, string $project, bool $withoutDev): array
     {
-        $command = sprintf('%s licenses%s --format json --working-dir %s', escapeshellarg($composer), $withoutDev ? ' --no-dev' : '' ,  escapeshellarg($project));
+        $command = sprintf('%s licenses%s --format json --working-dir %s', escapeshellarg($composer), $withoutDev ? ' --no-dev' : '',  escapeshellarg($project));
 
         return $this->exec($command);
     }

--- a/src/DependencyLoader.php
+++ b/src/DependencyLoader.php
@@ -24,9 +24,9 @@ class DependencyLoader implements DependencyLoaderContract
     /**
      * @throws CommandExecutionException
      */
-    public function loadDependencies(string $composer, string $project): array
+    public function loadDependencies(string $composer, string $project, bool $withoutDev): array
     {
-        $commandOutput = $this->runComposerLicenseCommand($composer, $project);
+        $commandOutput = $this->runComposerLicenseCommand($composer, $project, $withoutDev);
 
         return $this->dependencyParser->parse(join(PHP_EOL, $commandOutput));
     }
@@ -34,9 +34,9 @@ class DependencyLoader implements DependencyLoaderContract
     /**
      * @throws CommandExecutionException
      */
-    private function runComposerLicenseCommand(string $composer, string $project): array
+    private function runComposerLicenseCommand(string $composer, string $project, bool $withoutDev): array
     {
-        $command = sprintf('%s licenses --format json --working-dir %s', escapeshellarg($composer), escapeshellarg($project));
+        $command = sprintf('%s licenses%s --format json --working-dir %s', escapeshellarg($composer), $withoutDev ? ' --no-dev' : '' ,  escapeshellarg($project));
 
         return $this->exec($command);
     }

--- a/src/DependencyLoader.php
+++ b/src/DependencyLoader.php
@@ -36,7 +36,7 @@ class DependencyLoader implements DependencyLoaderContract
      */
     private function runComposerLicenseCommand(string $composer, string $project, bool $withoutDev): array
     {
-        $command = sprintf('%s licenses%s --format json --working-dir %s', escapeshellarg($composer), $withoutDev ? ' --no-dev' : '',  escapeshellarg($project));
+        $command = sprintf('%s licenses%s --format json --working-dir %s', escapeshellarg($composer), $withoutDev ? ' --no-dev' : '', escapeshellarg($project));
 
         return $this->exec($command);
     }

--- a/src/ReportCommand.php
+++ b/src/ReportCommand.php
@@ -38,6 +38,13 @@ class ReportCommand extends Command implements LicenseLookupAware, DependencyLoa
                 'composer'
             ),
             new InputOption(
+                'no-dev',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Do not include dev dependencies',
+                'false'
+            ),
+            new InputOption(
                 'no-cache',
                 null,
                 InputOption::VALUE_NONE,
@@ -77,7 +84,8 @@ class ReportCommand extends Command implements LicenseLookupAware, DependencyLoa
 
         $dependencies = $this->dependencyLoader->loadDependencies(
             $input->getOption('composer'),
-            $input->getOption('project-path')
+            $input->getOption('project-path'),
+            ($input->getOption('no-dev') ?? 'true') === 'true'
         );
 
         $dependencies = $this->filterLicenses($dependencies, $input->getOption('filter'));

--- a/tests/DependencyLoaderTest.php
+++ b/tests/DependencyLoaderTest.php
@@ -36,7 +36,7 @@ class DependencyLoaderTest extends TestCase
         $this->assertEquals("'./composerpath/composer-binary' licenses --format json --working-dir '/some/directory'", $command);
     }
 
-        /**
+    /**
      * @test
      *
      * @requires OS Linux|Darwin


### PR DESCRIPTION
This is disabled by default to preserve current behaviour.

It is important to make the difference between dependencies used in the development and dependencies used in the release build. E.g. you could use a GPL 2 tool in your development but that does not mean that you have to put your full code in that same license due to the viral nature.

By adding the `--no-dev` tag we allow to scan only the production build dependencies.

Added one extra test to make sure it works as expected.
Also tested manually on that very same code base:
![image](https://github.com/user-attachments/assets/4b88d5fb-6187-41a9-881f-ded35f76415f)
