### PR TITLE
fix php 8.4 implicit nullable param deprecation

### DIFF
--- a/src/LicenseLookup.php
+++ b/src/LicenseLookup.php
@@ -27,7 +27,7 @@ class LicenseLookup implements LicenseLookupContract
         'proprietary',
     ];
 
-    public function __construct(ClientInterface $http, CacheInterface $cache = null)
+    public function __construct(ClientInterface $http, ?CacheInterface $cache = null)
     {
         $this->http = $http;
         $this->cache = $cache ?? new FilesystemAdapter('FilesystemCache', 3600, __DIR__.'/../.cache');


### PR DESCRIPTION
PHP 8.4 deprecates implicit nullable parameter types. This PR updates function signatures to use explicit ?Type notation, which has been supported since PHP 7.1. This ensures compatibility and prevents deprecation warnings.