### PR TITLE
Use symfony/cache compatible cache key

### DIFF
--- a/src/LicenseLookup.php
+++ b/src/LicenseLookup.php
@@ -35,7 +35,7 @@ class LicenseLookup implements LicenseLookupContract
 
     public function lookUp(string $licenseName): License
     {
-        return $this->cache->get($licenseName, function () use ($licenseName) {
+        return $this->cache->get(str_replace(['{','}','(',')','/','\\','@',':'], '_', $licenseName), function () use ($licenseName) {
             try {
                 $detailsPageUrl = $this->queryForDetailPageUrl($licenseName);
 


### PR DESCRIPTION
Some packages use characters in composer.json's `license` field which are not allowed in [symfony/cache](https://github.com/symfony/cache/blob/6a208f32fb3ff51f0d0eb5e207a6462d4d1a9409/CacheItem.php#L139-L141). In this case, `vendor/bin/composer-license-checker report` gets aborted with

> Cache key "(Apache-2.0 or GPL-2.0)" contains reserved characters "{}()/\@:". 

This example comes from https://github.com/voku/portable-utf8/blob/c4b377468db50ba8e10ec01ac683271a0ab10c8f/composer.json#L14

This PR replaces such characters with `_`.